### PR TITLE
Fix matt-major/appdynamics-node#4.

### DIFF
--- a/lib/appdynamics-node.js
+++ b/lib/appdynamics-node.js
@@ -34,7 +34,7 @@ var responseHandler = function(callback, err, response) {
       callback(err, response.body);
     }
   }
-}
+};
 
 /**
  * AppDynamics Client Constructor

--- a/lib/appdynamics-node.js
+++ b/lib/appdynamics-node.js
@@ -24,6 +24,18 @@
 
 var request = require('request');
 
+var responseHandler = function(callback, err, response) {
+  if(err) {
+    callback(err, response);
+  } else {
+    if(response.statusCode >= 400) {
+      callback(response.statusCode, response);
+    } else {
+      callback(err, response.body);
+    }
+  }
+}
+
 /**
  * AppDynamics Client Constructor
  * @param options (url, port, path, username, password)
@@ -46,9 +58,7 @@ module.exports = AppDynamics;
  */
 AppDynamics.prototype.applicationsGetAll = function (callback) {
   var url = this.connection + 'applications' + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -59,9 +69,7 @@ AppDynamics.prototype.applicationsGetAll = function (callback) {
  */
 AppDynamics.prototype.businessTransactionsGetAll = function (applicationName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/business-transactions' + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -72,9 +80,7 @@ AppDynamics.prototype.businessTransactionsGetAll = function (applicationName, ca
  */
 AppDynamics.prototype.tiersGetAll = function (applicationName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/tiers' + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -85,9 +91,7 @@ AppDynamics.prototype.tiersGetAll = function (applicationName, callback) {
  */
 AppDynamics.prototype.nodesGetAll = function (applicationName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/nodes' + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -99,9 +103,7 @@ AppDynamics.prototype.nodesGetAll = function (applicationName, callback) {
  */
 AppDynamics.prototype.nodesGetByName = function (applicationName, nodeName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/nodes/' + nodeName + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -113,9 +115,7 @@ AppDynamics.prototype.nodesGetByName = function (applicationName, nodeName, call
  */
 AppDynamics.prototype.nodesGetByTier = function (applicationName, tierName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/tiers/' + tierName + '/nodes' + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };
 
 /**
@@ -127,7 +127,5 @@ AppDynamics.prototype.nodesGetByTier = function (applicationName, tierName, call
  */
 AppDynamics.prototype.tiersGetByName = function (applicationName, tierName, callback) {
   var url = this.connection + 'applications/' + applicationName + '/tiers/' + tierName + this.outputType;
-  request.get(url, function (err, response) {
-    callback(err, response.body);
-  });
+  request.get(url, responseHandler.bind(this, callback));
 };


### PR DESCRIPTION
This will do the following:
- In case the HTTP client calls the callback with an error, this error will be handed over to the user's callback alongside the response object from the HTTP client, which seems to be undefined all the time in this case.
- In case the HTTP client calls back with no error, but `response.statusCode >=400`, it'll call the user's callback with `response.statusCode` as 1st and `response` as 2nd parameter.
- In any other case it will call the user's callback with the HTTP client's `err` and `resposne.body` as arguments, which maintains backwards compatibility.
